### PR TITLE
For consistency with non-sessions tests use nonconcurrent single

### DIFF
--- a/mpi/pt2pt/osu_latency_sessions.c
+++ b/mpi/pt2pt/osu_latency_sessions.c
@@ -26,7 +26,7 @@ main (int argc, char *argv[])
     options.bench = PT2PT;
     options.subtype = LAT;
     const char pset_name[] = "mpi://world";
-    MPI_Flags flags = MPI_FLAG_THREAD_CONCURRENT;
+    MPI_Flags flags = MPI_FLAG_THREAD_NONCONCURRENT_SINGLE;
     MPI_Group wgroup = MPI_GROUP_NULL;
 
 

--- a/mpi/pt2pt/osu_mbw_mr_sessions.c
+++ b/mpi/pt2pt/osu_mbw_mr_sessions.c
@@ -34,7 +34,7 @@ int main(int argc, char *argv[])
     int numprocs, rank, rc;
     int c, curr_size;
     const char pset_name[] = "mpi://world";
-    MPI_Flags flags = MPI_FLAG_THREAD_CONCURRENT;
+    MPI_Flags flags = MPI_FLAG_THREAD_NONCONCURRENT_SINGLE;
     MPI_Group wgroup = MPI_GROUP_NULL;
 
     loop_override = 0;


### PR DESCRIPTION
Signed-off-by: Nathan Hjelm <hjelmn@me.com>